### PR TITLE
Add GitHub Action to lint and build Flatpak for `eos` template

### DIFF
--- a/templates/eos/.github/workflows/ci.yml
+++ b/templates/eos/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+  pull_request:
+    branches: [ main ]
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  flatpak:
+    name: Flatpak
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/elementary/flatpak-platform/runtime:daily
+      options: --privileged
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build
+        uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+        with:
+          bundle: ${PROGRAM_NAME}.flatpak
+          manifest-path: com.github.${USERNAME}.${PROGRAM_NAME}.yml
+          run-tests: true
+          repository-name: appcenter
+          repository-url: https://flatpak.elementary.io/repo.flatpakrepo
+          cache-key: "flatpak-builder-${{ github.sha }}"
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    container:
+      image: valalang/lint
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Lint
+        run: io.elementary.vala-lint -d .


### PR DESCRIPTION
For #9.

This makes a couple of assumptions:
- that the user will use `main` as the default branch
- and they will set up a secret token for GitHub Actions