### PR TITLE
GNOME template enhancements

### DIFF
--- a/templates/gnome/COPYING
+++ b/templates/gnome/COPYING
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    ${APP_TITLE} -- ${APP_SUMMARY}
-    Copyright (C) 2021, ${AUTHOR}
+    ${PROJECT_NAME} -- ${APP_SUMMARY}
+    Copyright (C) 2023, ${AUTHOR}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    ${APP_TITLE},  Copyright (C) 2021,  ${AUTHOR}
+    ${PROJECT_NAME},  Copyright (C) 2023,  ${AUTHOR}
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/templates/gnome/README.md
+++ b/templates/gnome/README.md
@@ -1,3 +1,3 @@
-# ${APP_TITLE}
+# ${PROJECT_NAME}
 
 ${APP_SUMMARY}

--- a/templates/gnome/build-aux/flatpak/${APP_ID}.yaml
+++ b/templates/gnome/build-aux/flatpak/${APP_ID}.yaml
@@ -3,6 +3,12 @@ runtime: org.gnome.Platform
 runtime-version: master
 sdk: org.gnome.Sdk
 
+sdk-extensions:
+- org.freedesktop.Sdk.Extension.vala
+build-options:
+  prepend-path: /usr/lib/sdk/vala/bin/
+  prepend-ld-library-path: /usr/lib/sdk/vala/lib
+
 command: ${APP_NAME}
 finish-args:
 - --share=ipc
@@ -22,34 +28,6 @@ cleanup:
 - '*.a'
 
 modules:
-
-# Libadwaita dependencies
-
-- name: libsass
-  buildsystem: meson
-  sources:
-  - type: git
-    url: https://github.com/lazka/libsass.git
-    branch: meson
-
-- name: sassc
-  buildsystem: meson
-  sources:
-  - type: git
-    url: https://github.com/lazka/sassc.git
-    branch: meson
-
-# Biography dependencies
-
-- name: libadwaita
-  buildsystem: meson
-  config-opts:
-  - -Dexamples=false
-  - -Dtests=false
-  sources:
-  - type: git
-    url: https://gitlab.gnome.org/GNOME/libadwaita.git
-    branch: main
 
 # Biography itself
 

--- a/templates/gnome/build-aux/flatpak/${APP_ID}.yaml
+++ b/templates/gnome/build-aux/flatpak/${APP_ID}.yaml
@@ -9,7 +9,7 @@ build-options:
   prepend-path: /usr/lib/sdk/vala/bin/
   prepend-ld-library-path: /usr/lib/sdk/vala/lib
 
-command: ${APP_NAME}
+command: ${APP_TITLE}
 finish-args:
 - --share=ipc
 - --socket=fallback-x11

--- a/templates/gnome/build-aux/flatpak/${APP_ID}.yaml
+++ b/templates/gnome/build-aux/flatpak/${APP_ID}.yaml
@@ -9,7 +9,7 @@ build-options:
   prepend-path: /usr/lib/sdk/vala/bin/
   prepend-ld-library-path: /usr/lib/sdk/vala/lib
 
-command: ${APP_TITLE}
+command: ${APP_EXE}
 finish-args:
 - --share=ipc
 - --socket=fallback-x11

--- a/templates/gnome/data/${APP_ID}.appdata.xml.in.in
+++ b/templates/gnome/data/${APP_ID}.appdata.xml.in.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>@APP_ID@</id>
-  <name>@APP_TITLE@</name>
+  <name>@APP_NAME@</name>
   <summary>@APP_SUMMARY@</summary>
   <description>
     <p>Some useful description</p>
@@ -9,7 +9,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <provides>
-    <binary>@APP_NAME@</binary>
+    <binary>@APP_EXE@</binary>
   </provides>
   <developer_name>${AUTHOR}</developer_name>
   <url type="homepage">https://link.to/your/project</url>

--- a/templates/gnome/data/${APP_ID}.desktop.in.in
+++ b/templates/gnome/data/${APP_ID}.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
-Name=@APP_TITLE@
+Name=${PROJECT_NAME}
 Icon=@APP_ID@
-Exec=@APP_NAME@
+Exec=@APP_EXE@
 Terminal=false
 Type=Application
 Categories=Utility;GNOME;GTK;

--- a/templates/gnome/meson.build
+++ b/templates/gnome/meson.build
@@ -7,7 +7,7 @@ project('${APP_NAME}', ['c', 'vala'],
 
 pkgdata_dir = get_option('prefix') / get_option('datadir') / meson.project_name()
 
-app_title = '${APP_TITLE}'
+app_exe = '${APP_EXE}'
 app_summary = '${APP_SUMMARY}'
 
 app_id = '${APP_ID}'
@@ -18,7 +18,7 @@ conf_data.set('APP_ID', app_id)
 conf_data.set('APP_PATH', '/' + app_id.replace('.', '/') + '/')
 conf_data.set('APP_NAME', app_name)
 
-conf_data.set('APP_TITLE', app_title)
+conf_data.set('APP_EXE', app_exe)
 conf_data.set('APP_SUMMARY', app_summary)
 
 ${APP_NAME}_sources = []

--- a/templates/gnome/resources/ui/MainWindow.ui
+++ b/templates/gnome/resources/ui/MainWindow.ui
@@ -4,9 +4,9 @@
   <requires lib="libadwaita" version="1.0"/>
 
   <template class="${APP_NAMESPACE}MainWindow" parent="AdwApplicationWindow">
-    <property name="title" translatable="yes">${APP_TITLE}</property>
-    <property name="default-width">1000</property>
-    <property name="default-height">700</property>
+    <property name="title" translatable="yes">${APP_NAME}</property>
+    <property name="default-width">580</property>
+    <property name="default-height">450</property>
     <property name="icon-name">${APP_ID}</property>
     <child>
       <object class="GtkBox">
@@ -19,6 +19,16 @@
                 <property name="menu-model">action_menu</property>
               </object>
             </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="vexpand">true</property>
+            <property name="valign">center</property>
+            <property name="label" translatable="yes">Hello World!</property>
+            <style>
+              <class name="title-1"/>
+            </style>
           </object>
         </child>
       </object>

--- a/templates/gnome/resources/ui/MainWindow.ui
+++ b/templates/gnome/resources/ui/MainWindow.ui
@@ -4,7 +4,7 @@
   <requires lib="libadwaita" version="1.0"/>
 
   <template class="${APP_NAMESPACE}MainWindow" parent="AdwApplicationWindow">
-    <property name="title" translatable="yes">${APP_NAME}</property>
+    <property name="title" translatable="yes">${PROJECT_NAME}</property>
     <property name="default-width">580</property>
     <property name="default-height">450</property>
     <property name="icon-name">${APP_ID}</property>
@@ -38,7 +38,7 @@
   <menu id="action_menu">
     <section>
       <item>
-        <attribute name="label">_About ${APP_NAME}</attribute>
+        <attribute name="label">_About ${PROJECT_NAME}</attribute>
         <attribute name="action">app.about</attribute>
       </item>
     </section>

--- a/templates/gnome/resources/ui/MainWindow.ui
+++ b/templates/gnome/resources/ui/MainWindow.ui
@@ -12,9 +12,25 @@
       <object class="GtkBox">
         <property name="orientation">vertical</property>
         <child>
-          <object class="AdwHeaderBar"></object>
+          <object class="AdwHeaderBar">
+            <child type="end">
+              <object class="GtkMenuButton">
+                <property name="icon-name">open-menu-symbolic</property>
+                <property name="menu-model">action_menu</property>
+              </object>
+            </child>
+          </object>
         </child>
       </object>
     </child>
   </template>
+
+  <menu id="action_menu">
+    <section>
+      <item>
+        <attribute name="label">_About ${APP_NAME}</attribute>
+        <attribute name="action">app.about</attribute>
+      </item>
+    </section>
+  </menu>
 </interface>

--- a/templates/gnome/src/Application.vala
+++ b/templates/gnome/src/Application.vala
@@ -49,7 +49,7 @@ namespace ${APP_NAMESPACE} {
             };
 
             Gtk.show_about_dialog (active_window,
-                "program_name", "${APP_NAME}",
+                "program_name", "${PROJECT_NAME}",
                 "logo-icon-name", Config.APP_ID,
                 "copyright", COPYRIGHT,
                 "version", Config.VERSION,

--- a/templates/gnome/src/Application.vala
+++ b/templates/gnome/src/Application.vala
@@ -33,7 +33,7 @@ namespace ${APP_NAMESPACE} {
         }
 
         protected override void activate () {
-            var win = get_active_window ();
+            var win = active_window;
             if (win == null) {
                 win = new ${APP_NAMESPACE}.MainWindow (this);
             }

--- a/templates/gnome/src/Application.vala
+++ b/templates/gnome/src/Application.vala
@@ -7,7 +7,8 @@ namespace ${APP_NAMESPACE} {
         }
 
         static ActionEntry[] ACTION_ENTRIES = {
-            { "quit", quit }
+            { "quit", quit },
+            { "about", on_about_action }
         };
 
         static AccelEntry[] ACCEL_ENTRIES = {
@@ -37,6 +38,26 @@ namespace ${APP_NAMESPACE} {
                 win = new ${APP_NAMESPACE}.MainWindow (this);
             }
             win.present ();
+        }
+
+        private void on_about_action () {
+            const string? COPYRIGHT = "Copyright \xc2\xa9 ${AUTHOR}";
+
+            const string? AUTHORS[] = {
+                "${AUTHOR}<${USERADDR}>",
+                null
+            };
+
+            Gtk.show_about_dialog (active_window,
+                "program_name", "${APP_NAME}",
+                "logo-icon-name", Config.APP_ID,
+                "copyright", COPYRIGHT,
+                "version", Config.VERSION,
+                "authors", AUTHORS,
+                /// TRANSLATORS: Write your Name<email> here
+                "translator-credits", _("translator-credits"),
+                null
+            );
         }
 
         static int main (string[] args) {

--- a/templates/gnome/src/MainWindow.vala
+++ b/templates/gnome/src/MainWindow.vala
@@ -1,6 +1,8 @@
 namespace ${APP_NAMESPACE} {
     [GtkTemplate (ui = "${APP_PATH}ui/MainWindow.ui")]
     class MainWindow : Adw.ApplicationWindow {
+        [GtkChild]
+        private unowned Gtk.Label label;
         public MainWindow (Application app) {
             Object (
                 application: app

--- a/templates/gnome/src/meson.build
+++ b/templates/gnome/src/meson.build
@@ -3,7 +3,7 @@ ${APP_NAME}_sources += [
   'MainWindow.vala'
 ]
 
-executable(app_title, ${APP_NAME}_sources,
+executable(app_exe, ${APP_NAME}_sources,
   vala_args: [
     '--target-glib=2.50',
     '--vapidir', vapi_dir,

--- a/templates/gnome/src/meson.build
+++ b/templates/gnome/src/meson.build
@@ -3,7 +3,7 @@ ${APP_NAME}_sources += [
   'MainWindow.vala'
 ]
 
-executable(app_name, ${APP_NAME}_sources,
+executable(app_title, ${APP_NAME}_sources,
   vala_args: [
     '--target-glib=2.50',
     '--vapidir', vapi_dir,

--- a/templates/gnome/template.json
+++ b/templates/gnome/template.json
@@ -5,14 +5,14 @@
             "auto": true,
             "default": "/${PROJECT_NAME}/\\s+//"
         },
-        "APP_TITLE": {
+        "APP_EXE": {
             "summary": "application binary name",
             "pattern": "[A-Za-z ]+"
         },
         "APP_ID": {
             "summary": "application ID",
             "pattern": "[a-z]{2,}(\\.\\w+){3}",
-            "default": "io.github.${USERNAME}.${PROJECT_NAME}"
+            "default": "io.github.${USERNAME}.${APP_NAME}"
         },
         "APP_NAMESPACE": {
             "summary": "application namespace",


### PR DESCRIPTION
Hello there! I worked in some enhancements in the GNOME Template, which include:

- About Dialog
- Added a little more content to the window, as well as using a `[GtkChild]`
- Remove Libadwaita from the Flatpak manifest as now the GNOME 42 runtime ships it
- Add the Vala SDK extension to the Flatpak manifest
- Fix: Use APP_TITLE as binary name